### PR TITLE
prioritizesVideoDevices

### DIFF
--- a/ios/RNAirPlayButtonManager.m
+++ b/ios/RNAirPlayButtonManager.m
@@ -17,5 +17,6 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_VIEW_PROPERTY(activeTintColor, UIColor);
 RCT_EXPORT_VIEW_PROPERTY(tintColor, UIColor);
+RCT_EXPORT_VIEW_PROPERTY(prioritizesVideoDevices, BOOL);
 
 @end

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import { requireNativeComponent, ViewProps } from 'react-native';
 type AirPlayButtonProps = ViewProps & {
   activeTintColor?: string;
   tintColor?: string;
+  prioritizesVideoDevices?: boolean;
   style?: React.CSSProperties;
 };
 


### PR DESCRIPTION
@dylancom, I added optional **prioritizesVideoDevices** property (https://developer.apple.com/documentation/avkit/avroutepickerview/3182882-prioritizesvideodevices?language=objc) to prioritise video airplay icon over audio.
![IMG_4078](https://user-images.githubusercontent.com/56805914/129988788-3efb302c-46c4-453f-88a0-06c4d099bd2d.jpg)
![IMG_4077](https://user-images.githubusercontent.com/56805914/129988793-668b7ee3-eea6-47a5-ad9e-66a0eebbb1a4.jpg)
